### PR TITLE
pwn(hexcore): prevent pkill escape in socat

### DIFF
--- a/pwn/hexcore/src/Dockerfile
+++ b/pwn/hexcore/src/Dockerfile
@@ -7,20 +7,21 @@ LABEL version="1.0"
 EXPOSE 9002
 
 RUN apt-get update && \
-    apt-get install -y socat && \
+    apt-get install -y socat bubblewrap && \
     rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos "" hexcore
 WORKDIR /home/hexcore
 
-COPY hexcore .
+COPY hexcore /usr/bin/
+COPY run.sh /usr/bin/
 COPY flag.txt .
 
 RUN chown -R root:root /home/hexcore
 RUN chmod -R a+rx /home/hexcore
 
 USER hexcore
-CMD ["socat", "TCP-LISTEN:9002,reuseaddr,fork,max-children=100", "EXEC:/home/hexcore/hexcore,stderr"]
+CMD ["socat", "TCP-LISTEN:9002,reuseaddr,fork,max-children=100", "EXEC:run.sh,stderr"]
 
 # docker build -t hexcore .
 # docker run -dp 9002:9002 -it --rm hexcore

--- a/pwn/hexcore/src/run.sh
+++ b/pwn/hexcore/src/run.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+bwrap \
+    --ro-bind /bin /bin \
+    --ro-bind /home /home \
+    --ro-bind /lib /lib \
+    --ro-bind /lib64 /lib64 \
+    --ro-bind /usr /usr \
+    --unshare-all \
+    hexcore


### PR DESCRIPTION
Lock down challenge to prevent getting actually pwned e.g. someone running `pkill socat` after getting shell. We should probably go through the other challenges to see if they can be secured better.